### PR TITLE
Catch case of missing secrets without panic

### DIFF
--- a/gcpvault.go
+++ b/gcpvault.go
@@ -90,6 +90,9 @@ func GetSecrets(ctx context.Context, cfg Config) (map[string]interface{}, error)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get secrets")
 	}
+	if secrets == nil {
+		return nil, errors.New("no secrets found")
+	}
 	return secrets.Data, nil
 }
 


### PR DESCRIPTION
a path with no secrets currently returns no error and `secrets` as nil which cases a panic