### PR TITLE
Adding basic GCF example

### DIFF
--- a/examples/gcp-http/README.md
+++ b/examples/gcp-http/README.md
@@ -1,0 +1,5 @@
+# The basic Google Cloud Functions Example
+
+This example shows how to use the init() function to fetch secrets from Vault before execution can start.
+
+To run this against your own Vault installation, update the values in `run_local.sh`.

--- a/examples/gcp-http/function.go
+++ b/examples/gcp-http/function.go
@@ -1,0 +1,33 @@
+package gcfexample
+
+import (
+	"context"
+	"net/http"
+
+	gcpvault "github.com/NYTimes/gcp-vault"
+	"github.com/kelseyhightower/envconfig"
+)
+
+func init() {
+	// Unlike GAE standard environment, GCF allows users to access the network on
+	// startup. This allows us to fetch our secrets in the init() function instead of
+	// hooking it in as a middleware.
+	initSecrets(context.Background())
+}
+
+var secrets map[string]interface{}
+
+func initSecrets(ctx context.Context) error {
+	var cfg gcpvault.Config
+	envconfig.Process("", &cfg)
+
+	var err error
+	secrets, err = gcpvault.GetSecrets(ctx, cfg)
+	return err
+}
+
+func MyFunction(w http.ResponseWriter, r *http.Request) {
+	secret := secrets["my-secret"].(string)
+
+	w.Write([]byte("the secret is: " + secret))
+}

--- a/examples/gcp-http/run_local.sh
+++ b/examples/gcp-http/run_local.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+export VAULT_ADDR="https://vault.example.com";
+
+vault login -method=github token=`cat ~/.config/vault/github` > /dev/null 2>&1;
+
+export VAULT_LOCAL_TOKEN="`cat ~/.vault-token`"
+export VAULT_ADDR="https://vault.example.com"
+export VAULT_SECRET_PATH="repo-name/secret/my-secrets"
+
+go test ./...


### PR DESCRIPTION
This was held out of the original release as GCF for Go was not out of alpha yet.