### PR TITLE
Check type sssertion before returning to avoid panic

### DIFF
--- a/gcpvault.go
+++ b/gcpvault.go
@@ -115,7 +115,11 @@ func GetVersionedSecrets(ctx context.Context, cfg Config) (map[string]interface{
 		return nil, err
 	}
 	// versioned secrets are contained under a 'data' key
-	return secs["data"].(map[string]interface{}), nil
+	s, ok := secs["data"].(map[string]interface{})
+	if !ok {
+		return nil, errors.New("no data in versioned secrets")
+	}
+	return s, nil
 }
 
 // PutVersionedSecrets writes versioned secrets to Vault at the configured path.


### PR DESCRIPTION
I ran into an issue when using `GetVersionedSecrets` where no error was returned from `GetSecrets` but a [warning message](https://github.com/hashicorp/vault/blob/master/api/secret.go#L30) was set on `api.Secret` and the `secs` map was nil, which caused a panic on the type assertion.

the warning message was:
```
Invalid path for a versioned K/V secrets engine. See the API docs for the appropriate API endpo
ints to use. If using the Vault CLI, use 'vault kv get' for this operation.
```
I have another PR to log these messages when data is nil #19