### PR TITLE
Return warning messages if no data is present

### DIFF
--- a/gcpvault.go
+++ b/gcpvault.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/vault/api"
@@ -92,6 +93,10 @@ func GetSecrets(ctx context.Context, cfg Config) (map[string]interface{}, error)
 	}
 	if secrets == nil {
 		return nil, errors.New("no secrets found")
+	}
+	if (secrets.Data == nil || len(secrets.Data) == 0) && secrets.Warnings != nil {
+		err := errors.New(strings.Join(secrets.Warnings, ","))
+		return nil, errors.Wrap(err, "no secrets found")
 	}
 	return secrets.Data, nil
 }


### PR DESCRIPTION
These could give a hint as to why no data is present.

See #17. Note, #18 is required for this to show up locally. 

Example of an error message I've received:

>Could not load vault secrets, no secrets found: Invalid path for a versioned K/V secrets engine. See the API docs for the appropriate API endpoints to use. If using the Vault CLI, use 'vault kv get' for this operation.