### PR TITLE
Adding the ability to use a custom HTTP client

### DIFF
--- a/account_appengine.go
+++ b/account_appengine.go
@@ -14,6 +14,6 @@ func getDefaultServiceAccountEmail(ctx context.Context, cfg Config) (string, err
 	return appengine.ServiceAccount(ctx)
 }
 
-func getHTTPClient(ctx context.Context) *http.Client {
+func getHTTPClient(ctx context.Context, _ Config) *http.Client {
 	return urlfetch.Client(ctx)
 }

--- a/account_gcp.go
+++ b/account_gcp.go
@@ -21,7 +21,7 @@ func getDefaultServiceAccountEmail(ctx context.Context, cfg Config) (string, err
 }
 
 func callMetadataService(ctx context.Context, cfg Config) (string, error) {
-	c := getHTTPClient(ctx)
+	c := getHTTPClient(ctx, cfg)
 	if cfg.MetadataAddress == "" {
 		cfg.MetadataAddress = "http://metadata"
 	}
@@ -55,7 +55,10 @@ func callMetadataService(ctx context.Context, cfg Config) (string, error) {
 	return result, nil
 }
 
-func getHTTPClient(ctx context.Context) *http.Client {
+func getHTTPClient(ctx context.Context, cfg Config) *http.Client {
+	if cfg.HTTPClient != nil {
+		return cfg.HTTPClient
+	}
 	return &http.Client{
 		Transport: &http.Transport{
 			IdleConnTimeout: 1 * time.Second,


### PR DESCRIPTION
I'm hoping to use an OpenCensus aware http.Client when fetching secrets for better monitoring. I believe this should do the trick.