### PR TITLE
NOT reusing the same *http.Client pointer to avoid after effects

### DIFF
--- a/gcpvault.go
+++ b/gcpvault.go
@@ -245,12 +245,15 @@ func newJWTBase(ctx context.Context, cfg Config) (string, error) {
 	}
 
 	hc := getHTTPClient(ctx, cfg)
-	// reuse base transport but sprinkle on the token source for IAM access
-	hc.Transport = &oauth2.Transport{
-		Source: tokenSource,
-		Base:   hc.Transport,
+	// reuse base transport and timeout but sprinkle on the token source for IAM access
+	hcIAM := &http.Client{
+		Timeout: hc.Timeout,
+		Transport: &oauth2.Transport{
+			Source: tokenSource,
+			Base:   hc.Transport,
+		},
 	}
-	iamClient, err := iam.New(hc)
+	iamClient, err := iam.New(hcIAM)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to init IAM client")
 	}


### PR DESCRIPTION
My last change introduced in #22 included a MAJOR flaw: it reused the inbound `http.Client` pointer when adding on an additional `http.Transport` layer before initiating the IAM client.

This caused a major issue in one of my applications that was communicating with a separate API. The `http.Client` was unexpectedly getting additional `Authorization` headers included in requests after using this (gcpvault) library. That API was seeing the header from this library's effects before a separate query param `access_token` and rejecting requests 😓

This PR creates a _new_ `*http.Client` variable instead of reusing the same one and should avoid the current problems introduced in v0.3.2.