### PR TITLE
Do not reuse transport

### DIFF
--- a/gcpvault.go
+++ b/gcpvault.go
@@ -245,12 +245,11 @@ func newJWTBase(ctx context.Context, cfg Config) (string, error) {
 	}
 
 	hc := getHTTPClient(ctx, cfg)
-	// reuse base transport and timeout but sprinkle on the token source for IAM access
+	// reuse timeout but sprinkle on the token source for IAM access
 	hcIAM := &http.Client{
 		Timeout: hc.Timeout,
 		Transport: &oauth2.Transport{
 			Source: tokenSource,
-			Base:   hc.Transport,
 		},
 	}
 	iamClient, err := iam.New(hcIAM)


### PR DESCRIPTION
Reusing the base transport can have unintended side effects, for example when setting `VAULT_CACERT` requests to the IAM API break as the cert store is modified.

Closes #24