### PR TITLE
Reuse the vault client and token if it is valid

### DIFF
--- a/gcpvault_test.go
+++ b/gcpvault_test.go
@@ -387,6 +387,8 @@ func TestPutVersionedSecrets(t *testing.T) {
 
 			secrets = test.startingSecrets
 
+			cachedClient = nil
+
 			vaultSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.Method {
 				case http.MethodPut:


### PR DESCRIPTION
With this change the vault client is cached between `Get` and `Put` calls and avoids logging into vault every time. We use this library to read a (growing) number of secrets at a certain interval and noticed a big overhead from always doing the full login for each `GetSecrets` call. This caches the `vClient` and also reuses the token if it is still valid. It still makes a `LookupSelf` call to vault but that is way less expensive than the whole login flow. This might not be the most elegant solution so let me know if you have other ideas.