### PR TITLE
Switch to using Vault's HTTP client as a base

### DIFF
--- a/account_gcp.go
+++ b/account_gcp.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/vault/api"
 	"github.com/pkg/errors"
 )
 
@@ -59,9 +60,11 @@ func getHTTPClient(ctx context.Context, cfg Config) *http.Client {
 	if cfg.HTTPClient != nil {
 		return cfg.HTTPClient
 	}
-	return &http.Client{
-		Transport: &http.Transport{
-			IdleConnTimeout: 1 * time.Second,
-		},
+
+	// start with Vault's http client and also configure an idle connection timeout
+	c := api.DefaultConfig().HttpClient
+	c.Transport = &http.Transport{
+		IdleConnTimeout: 1 * time.Second,
 	}
+	return c
 }

--- a/account_gcp.go
+++ b/account_gcp.go
@@ -63,8 +63,6 @@ func getHTTPClient(ctx context.Context, cfg Config) *http.Client {
 
 	// start with Vault's http client and also configure an idle connection timeout
 	c := api.DefaultConfig().HttpClient
-	c.Transport = &http.Transport{
-		IdleConnTimeout: 1 * time.Second,
-	}
+	c.Transport.(*http.Transport).IdleConnTimeout = 1 * time.Second
 	return c
 }


### PR DESCRIPTION
Hashicorp suggests [starting with their HTTP client](https://github.com/hashicorp/vault/blob/api/v1.0.3/api/client.go#L69-L74) and building on top of it -- I came across this when auditing to make sure all our calls in our services have timeouts

 