### PR TITLE
Unpin go 1.12

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ workspace:
 
 steps:
 - name: mod-download
-  image: golang:1.12
+  image: golang:1
   commands:
   - go mod download
   environment:
@@ -21,7 +21,7 @@ steps:
   - clone
 
 - name: test
-  image: golang:1.12
+  image: golang:1
   commands:
   - go test -race -vet all -mod readonly ./...
   depends_on:


### PR DESCRIPTION
Build and test pipeline Go version is too old, updated to use `1`.